### PR TITLE
directory.py: fix update_entry_type.

### DIFF
--- a/psptool/directory.py
+++ b/psptool/directory.py
@@ -128,7 +128,7 @@ class Directory(NestedBuffer):
     def update_entry_fields(self, entry: Entry, type_, size, offset):
         entry_index = None
         for index, my_entry in enumerate(self.entries):
-            if my_entry == entry:
+            if my_entry.type == entry.type:
                 entry_index = index
                 break
 


### PR DESCRIPTION
If an entry is moved, it will never be equal to the original entry.
We should compare entry types instead.