### PR TITLE
Emit a warning if a directory can't be parsed correctly.

### DIFF
--- a/psptool/directory.py
+++ b/psptool/directory.py
@@ -145,6 +145,10 @@ class Directory(NestedBuffer):
                                       entry_fields['size'],
                                       entry_fields['offset'],
                                       self.blob)
+                                      
+            if entry is None:
+                print_warning(f"Entry @ {entry_fields['offset']} of size {entry_fields['size']} of type {entry_fields['type']} couldn't be parsed")
+                continue
 
             for existing_entry in self.blob.unique_entries:
                 if entry == existing_entry:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = psptool
-version = 2.2
+version = 2.2.1
 author = Christian Werling
 author_email = cwerling@posteo.de
 url = https://github.com/PSPReverse/psptool


### PR DESCRIPTION
Partial fix for #30, I am able to load the Gigabyte B450M DS3H v2 - f60 firmware image with this change.