### PR TITLE
Make sure there's a signed_entry property for this entry

### DIFF
--- a/psptool/__main__.py
+++ b/psptool/__main__.py
@@ -187,7 +187,7 @@ def main():
             if args.privkeystub:
                 privkeys = PrivateKeyDict.read_from_files(args.privkeystub, args.privkeypass)
 
-            if entry.signed_entity:
+            if 'signed_entity' in entry and entry.signed_entity:
                 entry.signed_entity.resign_and_replace(privkeys=privkeys, recursive=True)
             else:
                 ph.print_warning("Did not resign anything since target entry is not signed")


### PR DESCRIPTION
Some image entries don't have the signed_entry property which would cause psptool to fail. This PR makes sure that the entry has that property before checking it.