### PR TITLE
directory: fix entry offset address mode handling and preserve NO_SIZE sentinel

### DIFF
--- a/psptool/directory.py
+++ b/psptool/directory.py
@@ -216,8 +216,8 @@ class Directory(NestedBuffer):
 
         # 2. Update fields
         entry.type = type_
-        entry.size = size
-        # todo: not necessarily here, but make sure the 0xb SOFT_FUSE_CHAIN's special size of 0xFF... stays intact
+        if entry.type not in File.NO_SIZE_ENTRY_TYPES:
+            entry.size = size
 
         # Convert the ROM buffer offset back to the value the entry expects, preserving address mode.
         # This mirrors the inverse of file_offset() in entry.py.

--- a/psptool/directory.py
+++ b/psptool/directory.py
@@ -71,7 +71,7 @@ class Directory(NestedBuffer):
             except Directory.ParseError as e:
                 # Handle empty entries gracefully (like master branch)
                 if "Empty entry" in str(e):
-                    fet.psptool.ph.print_warning(f"Skipping empty directory entry at offset 0x{offset:x}")
+                    fet.psptool.ph.print_warning(f"Skipping empty directory entry at offset 0{offset:x}")
                     return []
                 else:
                     # Re-raise other parse errors
@@ -217,8 +217,25 @@ class Directory(NestedBuffer):
         # 2. Update fields
         entry.type = type_
         entry.size = size
-        entry.offset = offset
-        # todo: allow updating the address_mode which consists of two bytes right here
+        # todo: not necessarily here, but make sure the 0xb SOFT_FUSE_CHAIN's special size of 0xFF... stays intact
+
+        # Convert the ROM buffer offset back to the value the entry expects, preserving address mode.
+        # This mirrors the inverse of file_offset() in entry.py.
+        addr_mode = self.address_mode
+        if addr_mode == 2 or addr_mode == 3:
+            addr_mode = entry.address_mode
+
+        if addr_mode == 0:
+            # x86 physical: preserve upper bits (e.g. 0xFF000000), replace lower bits
+            addr_mask = self.rom.addr_mask
+            upper_mask = 0xFFFFFFFF ^ addr_mask
+            entry.offset = (entry.offset & upper_mask) | (offset & addr_mask)
+        elif addr_mode == 1:
+            entry.offset = offset
+        elif addr_mode == 2 or addr_mode == 3:
+            entry.offset = offset - self.buffer_offset
+        else:
+            entry.offset = offset
 
         # 3. Update checksum
         self.update_checksum()

--- a/psptool/directory.py
+++ b/psptool/directory.py
@@ -71,7 +71,7 @@ class Directory(NestedBuffer):
             except Directory.ParseError as e:
                 # Handle empty entries gracefully (like master branch)
                 if "Empty entry" in str(e):
-                    fet.psptool.ph.print_warning(f"Skipping empty directory entry at offset 0{offset:x}")
+                    fet.psptool.ph.print_warning(f"Skipping empty directory entry at offset 0x{offset:x}")
                     return []
                 else:
                     # Re-raise other parse errors

--- a/psptool/file.py
+++ b/psptool/file.py
@@ -248,9 +248,6 @@ class File(NestedBuffer):
 
     @classmethod
     def from_entry(cls, parent_directory, parent_buffer, entry, blob, psptool):
-        if entry.type in cls.NO_SIZE_ENTRY_TYPES:
-            entry.size = 0
-
         assert entry.file_offset() < len(parent_directory.rom), "File offset overflows ROM bounds!"
         file_args = [parent_directory, parent_buffer, entry.file_offset(), entry, blob, psptool]
 


### PR DESCRIPTION
## Summary

- Fix `update_entry_fields` in `directory.py` to properly convert ROM buffer offsets back to the value expected by a directory entry, respecting the entry's address mode. Previously the raw buffer offset was written directly, which produced wrong values for x86-physical (mode 0) and relative (mode 2/3) entries.
- Preserve `NO_SIZE_ENTRY_TYPES` sentinel sizes (e.g. `0xFFFFFFFF` for `SOFT_FUSE_CHAIN`) during updates. The old code in `file.py` unconditionally zeroed `entry.size` for these types at parse time, destroying the sentinel; that logic is removed and `update_entry_fields` now skips overwriting the size for these types instead.

## Address mode handling details

| Mode | Encoding |
|------|----------|
| 0 (x86 physical) | Upper bits preserved, lower bits replaced using `rom.addr_mask` |
| 1 (flash offset) | Written as-is |
| 2 / 3 (relative) | Stored as `offset - directory.buffer_offset` |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)