### PR TITLE
Add support of AMD 4800S Desktop Kit

### DIFF
--- a/psptool/blob.py
+++ b/psptool/blob.py
@@ -47,6 +47,7 @@ class Blob(NestedBuffer):
             0xe20000,
             0xc20000,
             0x820000,
+            0x120000,
         ]
 
         possible_rom_sizes = [32, 16, 8]


### PR DESCRIPTION
AMD 4800S Desktop Kit's FET is at offset 0x120000, so add it.

reference: https://archive.org/details/w-25-q-128-jw-amd-4800-s