### PR TITLE
Repoint test-fixtures submodule and add EPYC integration test scaffolding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/integration/fixtures"]
 	path = tests/integration/fixtures
-	url = git@github.com:cwerling/PSPTool-fixtures.git
+	url = git@github.com:PSPReverse/Test-PSPTool.git

--- a/tests/integration/test_rom_files.py
+++ b/tests/integration/test_rom_files.py
@@ -8,7 +8,7 @@ from psptool import PSPTool
 from psptool.header_file import HeaderFile
 
 dirname = os.path.dirname(__file__)
-rom_fixtures_path = os.path.join(dirname, 'fixtures/roms')
+rom_fixtures_path = os.path.join(dirname, 'fixtures/test_files')
 
 # todo: add extraction tests
 #  - extract entry and make sure it has the correct size
@@ -92,6 +92,65 @@ class TestRomFiles(unittest.TestCase):
                                         out_decrypted = entry.get_decrypted_decompressed_body()
                                     # Check that there were no warnings
                                     self.assertEqual(stderr_buf.getvalue(), "")
+
+
+class TestZenGenerationBackfill(unittest.TestCase):
+    # Maps fixture filename (relative to fixtures/roms) to the substring
+    # that must appear in zen_generation for every directory in the ROM.
+    # Single-generation EPYC images are the negative test set fixed by the
+    # PSP_FW_BOOT_LOADER back-fill path. Each entry corresponds to a row
+    # in issue.md's "Test ROMs — direct download URLs" section; SHA-256s
+    # there can be used to verify the unwrapped ROM matches.
+    EPYC_EXPECTATIONS = {
+        'ASUS_KRPA-U16-ASUS-4501.CAP':   'Zen 2',  # Rome (SP3)
+        'ASUS_KRPA-U16-M-ASUS-1002.CAP': 'Zen 3',  # Milan (SP3)
+        'ASUS_K14PA-U12-ASUS-2305.CAP':  'Zen 4',  # Genoa (SP5)
+        'ASUS_S14NA-U12-ASUS-0903.CAP':  'Zen 4',  # Siena (SP6); Zen 4c shares Zen 4 BL major
+        'Tyan_S8050GM4NE-2T_V3.04.rom':  'Zen 5',  # Turin (SP5)
+    }
+
+    def _find_fixture(self, basename):
+        for subdir, _dirs, files in os.walk(rom_fixtures_path):
+            if basename in files:
+                return os.path.join(subdir, basename)
+        return None
+
+    def test_epyc_zen_generation_set(self):
+        present = {n: p for n, p in
+                   ((n, self._find_fixture(n)) for n in self.EPYC_EXPECTATIONS)
+                   if p is not None}
+        if not present:
+            self.skipTest(
+                f"No EPYC fixtures present under {rom_fixtures_path}; "
+                f"this assertion activates after Test-PSPTool gains the EPYC "
+                f"corpus and the gitlink in this repo is bumped"
+            )
+        for name, path in present.items():
+            expected = self.EPYC_EXPECTATIONS[name]
+            with self.subTest(name):
+                with io.StringIO() as stderr_buf, contextlib.redirect_stderr(stderr_buf):
+                    pt = psptool.PSPTool.from_file(path)
+                self.assertTrue(len(pt.blob.roms) > 0, f"{name}: no ROMs parsed")
+                # Find at least one ROM whose directories all match the
+                # expected generation. Multi-ROM BIOSes (e.g. Tyan Turin
+                # ships a Genoa+Turin pair) may carry one ROM at a different
+                # generation, but the expected one must be present.
+                matching_roms = [
+                    r for r in pt.blob.roms
+                    if r.directories and all(
+                        d.zen_generation is not None and expected in d.zen_generation
+                        for d in r.directories
+                    )
+                ]
+                self.assertTrue(
+                    matching_roms,
+                    f"{name}: no ROM in the file has all directories tagged {expected!r}; "
+                    f"got "
+                    + repr([
+                        [d.zen_generation for d in r.directories]
+                        for r in pt.blob.roms
+                    ])
+                )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Two pieces of infrastructure cleanup that were originally bundled with #85 but are independently useful:

1. **Repoint the dead test-fixtures submodule.** `tests/integration/fixtures` currently points at `git@github.com:cwerling/PSPTool-fixtures.git`, which returns "Repository not found" — almost certainly collateral from the LFS-quota recreations the commit log mentions. Anyone running `git submodule update --init` on a fresh checkout today fails immediately. Switching to `git@github.com:PSPReverse/Test-PSPTool.git`, which is the org's active firmware corpus (54 ROMs, AM4 / X399 / Naples era), restores submodule init.
2. **Add scaffolding for an EPYC integration test.** Layout shifts from `fixtures/roms/` to `fixtures/test_files/` to match the Test-PSPTool repo's flat layout, and `TestZenGenerationBackfill` is added to `tests/integration/test_rom_files.py`. It maps the 5 EPYC fixture filenames to expected Zen generations and asserts via `_find_fixture` + `subTest`. The class **skips cleanly** today (`No EPYC fixtures present under tests/integration/fixtures/test_files`) — it starts asserting only after Test-PSPTool gains the EPYC ROMs and the gitlink in this PR is bumped to a SHA that contains them.

## Why this is its own PR

This work is a strict superset of "the submodule URL is dead." The integration-test class is dormant scaffolding until Test-PSPTool catches up, and bundling it with the back-fill in #85 muddies the review (one PR mixing fix-the-bug with fix-the-CI-corpus-pointer). Keeping them separate means:

- #85 reviewers focus on the back-fill on its merits — fully covered by unit tests, no submodule dependency.
- This PR reviewers focus on whether the move to `PSPReverse/Test-PSPTool` is the right destination, and whether the dormant test class shape is acceptable.
- Either can be merged before the other, in any order.

## What's in the PR

Single commit:

- `.gitmodules` — URL change to `git@github.com:PSPReverse/Test-PSPTool.git`
- `tests/integration/fixtures` — gitlink moved to current `Test-PSPTool` master HEAD `bca9c0e`. Real commit, exists, has the existing 54-ROM corpus.
- `tests/integration/test_rom_files.py` — `rom_fixtures_path` updated to `fixtures/test_files`; new `TestZenGenerationBackfill` class.

## Test plan

- [x] **Existing integration tests** (`TestRomFiles.*`): runs against the new submodule pointer (Test-PSPTool master, 54 ROMs, AM4 / X399 / Naples era) — all pass, AM4 combo control `X470D4U2-2T 3.40` keeps existing combo_dir output unchanged.
- [x] **`TestZenGenerationBackfill`**: skips with the documented "No EPYC fixtures present" message, exactly as expected on this gitlink.

## Follow-up

A companion change in `PSPReverse/Test-PSPTool` adds 5 EPYC fixture files (Rome / Milan / Genoa / Siena / Turin) under `test_files/` and refreshes `test_psptool.py` for the current PSPTool API (it imports `HeaderEntry` and walks `psp.blob.fets`, both gone). Once that lands, a one-line gitlink bump in this repo flips `TestZenGenerationBackfill` from skip to assert.
